### PR TITLE
Fix missing Python 3.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:18.04
 
 # -- Install Pipenv:
-RUN apt update && apt install python-pip python3-pip time git -y && pip3 install pipenv
+RUN apt update && apt install python-pip python3.7 python3-pip time git -y && pip3 install pipenv
 
 ENV LC_ALL C.UTF-8
 ENV LANG C.UTF-8


### PR DESCRIPTION
Hi @kennethreitz,

I faced a few issues when I tried to to run tests for the [pipenv](https://github.com/pypa/pipenv) by `docker-compose up` command.
This PR adds missing `python3.7` which is required since pypa/pipenv@2addee4fd638ca397fe0ad17d37a2966df2173d5 was applied.
So, I need you to update `kennethreitz/pipenv-tests` image.

Thank you!

P.S. I'll also create a PR that fixes one more issue of `pipenv`.